### PR TITLE
Update Servant and LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: false
 
+language: c
+
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+
 cache:
   directories:
   - $HOME/.stack
@@ -8,17 +15,12 @@ before_install:
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
-- export PATH=/opt/ghc/$GHCVER/bin:$PATH
 
 matrix:
   include:
-  - env: GHCVER=7.10.3 STACK_YAML=stack.yaml
-    addons:
-      apt:
-        sources:
-        - hvr-ghc
-        packages:
-        - ghc-7.10.3
+  - env: ARGS=""
+  #- env: ARGS="--resolver lts-6"
+  #- env: ARGS="--resolver lts"
 
 script:
-- stack --no-terminal --skip-ghc-check test
+- stack $ARGS --no-terminal --install-ghc test --haddock --no-haddock-deps

--- a/mailchimp.cabal
+++ b/mailchimp.cabal
@@ -40,14 +40,14 @@ library
       Web.MailChimp.List
       Web.MailChimp.List.Member
   build-depends:
-      aeson >= 0.11 && < 0.12
+      aeson >= 0.11 && < 1.1
     , attoparsec >= 0.13 && < 0.14
     , base >= 4.8 && < 4.10
     , bytestring
-    , http-client >= 0.4 && < 0.5
-    , http-client-tls >= 0.2 && < 0.3
-    , servant >= 0.7 && < 0.8
-    , servant-client >= 0.7 && < 0.8
+    , http-client >= 0.4 && < 0.6
+    , http-client-tls >= 0.2 && < 0.4
+    , servant >= 0.7 && < 0.10
+    , servant-client >= 0.7 && < 0.10
     , text >= 1.2 && < 1.3
     , transformers
   default-language:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-6.16
+resolver: nightly-2016-10-28


### PR DESCRIPTION
@jpvillaisaza Could you take a look please? I updated the solver and in doing so. The Servant Client library changed so I had to make some changes to the endpoints.
What do you think? 

So it seems that since this uses the latest version of servant. This breaks some behavior and lts-6.27 and lts-7.16 use older versions of servant and servant-client. So it works with the nightly solver but no more than that