### PR TITLE
A few small fixes

### DIFF
--- a/mailchimp.cabal
+++ b/mailchimp.cabal
@@ -42,7 +42,7 @@ library
   other-modules:
       Paths_mailchimp
   build-depends:
-      aeson >= 1.1 && < 1.2
+      aeson >= 1.0 && < 1.2
     , attoparsec >= 0.13 && < 0.14
     , base >= 4.8 && < 4.10
     , bytestring


### PR DESCRIPTION
I added a few things here:

* this library works with aeson with a slightly lower bound, which I bumped down
* the list members responses wasn't quite right, it was expecting an array as a response but the 
actual response is an object with a key "members"
* added a few more relevant fields to the list remember response object
* add pagination for the list members endpoint. I also added a helper function to get all of the list members by iterating over the pages.


Apologies for not splitting these into multiple PRs! Feel free to pick and choose parts you like. 